### PR TITLE
GitHub login設定とTwitter loginの無効化

### DIFF
--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -23,13 +23,13 @@
 
   <%- if devise_mapping.omniauthable? %>
 
-    <%- if devise_mapping.confirmable? && controller_name != 'registrations' %>
+    <%#- if devise_mapping.confirmable? && controller_name != 'registrations' %>
       <%# Show "Sign in with Twitter" only login with already registrated user %>
-      <%= link_to user_twitter_omniauth_authorize_path, method: :post, class: "btn btn-twitter" do %>
-        <i class="icon-twitter"></i>
-        <span class="btn-text-middle">Sign in with Twitter</span>
-      <% end %>
-    <% end %>
+      <%#= link_to user_twitter_omniauth_authorize_path, method: :post, class: "btn btn-twitter" do %>
+        <%# <i class="icon-twitter"></i> %>
+        <%# <span class="btn-text-middle">Sign in with Twitter</span> %>
+      <%# end %>
+    <%# end %>
     <%= link_to user_github_omniauth_authorize_path, method: :post, class: "btn btn-github" do %>
       <i class="icon-github"></i>
       <span class="btn-text-middle">Sign in with GitHub</span>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -242,7 +242,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   config.omniauth :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'], scope: 'user:email'
-  config.omniauth :twitter, ENV['TWITTER_KEY'], ENV['TWITTER_SECRET']
+  # config.omniauth :twitter, ENV['TWITTER_KEY'], ENV['TWITTER_SECRET']
   config.omniauth :developer unless Rails.env.production?
 
   # ==> Warden configuration

--- a/deploy/ecs-task-def-worker.json
+++ b/deploy/ecs-task-def-worker.json
@@ -121,6 +121,14 @@
         {
           "name": "SMTP_PASSWORD",
           "valueFrom": "{{ secretsmanager_arn `CfpApp/SmtpAuth` }}:password::"
+        },
+        {
+          "name": "GITHUB_KEY",
+          "valueFrom": "{{ secretsmanager_arn `CfpApp/GitHubOAuth` }}:clientId::"
+        },
+        {
+          "name": "GITHUB_SECRET",
+          "valueFrom": "{{ secretsmanager_arn `CfpApp/GithubOAuth` }}:clientSecret::"
         }
       ],
       "versionConsistency": ""

--- a/deploy/ecs-task-def.json
+++ b/deploy/ecs-task-def.json
@@ -112,6 +112,14 @@
         {
           "name": "SMTP_PASSWORD",
           "valueFrom": "{{ secretsmanager_arn `CfpApp/SmtpAuth` }}:password::"
+        },
+        {
+          "name": "GITHUB_KEY",
+          "valueFrom": "{{ secretsmanager_arn `CfpApp/GitHubOAuth` }}:clientId::"
+        },
+        {
+          "name": "GITHUB_SECRET",
+          "valueFrom": "{{ secretsmanager_arn `CfpApp/GithubOAuth` }}:clientSecret::"
         }
       ],
       "versionConsistency": ""


### PR DESCRIPTION
- jaws-feast-2025 orgでOAuth app（festa-cfp-app）を作成し、cfp-appからGitHub loginできるようにした
  - cf. https://github.com/omniauth/omniauth-github
- Twitter loginは利用しないのでコメントアウト